### PR TITLE
Add Taskfile for common Go development tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,83 @@
+version: '3'
+
+vars:
+  BINARY_NAME: snf2ical
+  BUILD_DIR: .
+  CMD_DIR: ./cmd
+
+tasks:
+  default:
+    desc: List all available tasks
+    cmds:
+      - task --list
+
+  build:
+    desc: Build the binary
+    cmds:
+      - go build -o {{.BINARY_NAME}} {{.CMD_DIR}}/snf2ical.go
+    sources:
+      - "**/*.go"
+      - go.mod
+      - go.sum
+    generates:
+      - "{{.BINARY_NAME}}"
+
+  test:
+    desc: Run all tests
+    cmds:
+      - go test -v ./...
+
+  test-coverage:
+    desc: Run tests with coverage report
+    cmds:
+      - go test -v -coverprofile=coverage.out ./...
+      - go tool cover -html=coverage.out -o coverage.html
+      - echo "Coverage report generated at coverage.html"
+
+  clean:
+    desc: Remove build artifacts
+    cmds:
+      - rm -f {{.BINARY_NAME}}
+      - rm -f coverage.out coverage.html
+      - rm -f *.ics
+
+  fmt:
+    desc: Format Go code
+    cmds:
+      - go fmt ./...
+
+  vet:
+    desc: Run go vet
+    cmds:
+      - go vet ./...
+
+  lint:
+    desc: Run golangci-lint (if installed)
+    cmds:
+      - golangci-lint run ./...
+    preconditions:
+      - sh: command -v golangci-lint
+        msg: "golangci-lint is not installed. Install from https://golangci-lint.run/usage/install/"
+
+  vendor:
+    desc: Update vendored dependencies
+    cmds:
+      - go mod tidy
+      - go mod vendor
+
+  run:
+    desc: Run the application with example flags
+    cmds:
+      - go run {{.CMD_DIR}}/snf2ical.go --help
+
+  install:
+    desc: Install the binary to $GOPATH/bin
+    cmds:
+      - go install {{.CMD_DIR}}/snf2ical.go
+
+  check:
+    desc: Run fmt, vet, and test
+    cmds:
+      - task: fmt
+      - task: vet
+      - task: test


### PR DESCRIPTION
## Summary
- Adds a Taskfile.yml with common Go development tasks including build, test, fmt, vet, lint, and more
- Provides convenient task runner integration for building, testing, and maintaining the project

## Test plan
- [ ] Verify Taskfile.yml is valid by running `task --list`
- [ ] Test build task with `task build`
- [ ] Test test task with `task test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added task automation configuration with predefined tasks for building, testing, code quality checks, and artifact management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->