### PR TITLE
Add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Build binaries
         run: |
           GOOS=linux  GOARCH=amd64 go build -o snf2ical-linux-amd64   ./cmd/snf2ical.go
-          GOOS=linux  GOARCH=arm64 go build -o snf2ical-linux-arm64   ./cmd/snf2ical.go
-          GOOS=darwin GOARCH=amd64 go build -o snf2ical-darwin-amd64  ./cmd/snf2ical.go
-          GOOS=darwin GOARCH=arm64 go build -o snf2ical-darwin-arm64  ./cmd/snf2ical.go
 
       - name: Upload binaries to release
         env:
@@ -32,6 +29,3 @@ jobs:
         run: |
           gh release upload "${{ github.ref_name }}" \
             snf2ical-linux-amd64 \
-            snf2ical-linux-arm64 \
-            snf2ical-darwin-amd64 \
-            snf2ical-darwin-arm64


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` that triggers on `v*` tags
- Builds the `snf2ical` binary for Linux amd64 and uploads it to the GitHub release

## Test plan

- [ ] Create and push a version tag (e.g. `git tag v0.1.0 && git push origin v0.1.0`)
- [ ] Verify the Actions workflow runs and attaches the binary to the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated release process to generate and deploy pre-built artifacts when version tags are published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->