### PR TITLE
Trigger release workflow on any tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - '*'
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

- Changes the tag pattern from `v*` to `*` so the workflow fires for tags like `2026.0` in addition to `v`-prefixed ones

## Test plan

- [ ] Merge and re-run the workflow manually against the existing `2026.0` release, or push a new tag to verify the binary is attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow trigger to activate for all tag names instead of version-specific tags only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->