### PR TITLE
Bump actions to v6 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` from v4 to v6
- Bumps `actions/setup-go` from v5 to v6

Both v4/v5 run on Node.js 20, which is deprecated in GitHub Actions and will be removed September 16, 2026. The v6 releases use Node.js 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->